### PR TITLE
Update pt_BR

### DIFF
--- a/nwg_clipman/langs/pt_BR
+++ b/nwg_clipman/langs/pt_BR
@@ -1,8 +1,8 @@
 {
-  "clear": "Claro",
+  "clear": "Limpar",
   "clear-clipboard-history": "Limpar histórico da área de transferência",
   "close": "Fechar",
-  "copy": "Cópia",
-  "preview": "Visualização",
-  "preview-unavailable": "Visualização indisponível"
+  "copy": "Copiar",
+  "preview": "Prévia",
+  "preview-unavailable": "Prévia indisponível"
 }


### PR DESCRIPTION
Hello there. I just started using nwg-clipman and the brazilian portuguese translation is a bit off. So I made some changes

"Claro" isn't the correct word for the context of this software translation wise, "Limpar", "Zerar" or "Apagar" are more fitting meaning that all them makes sense for emptying the list. Prévia seems also more fitting etc.

On the case of "claro", it can mean bright, of course, transparent, translucent etc. This seems to have been translated by using a tranlation tool/auto-translated.