### PR TITLE
chore(lang): update spanish translations

### DIFF
--- a/nwg_clipman/langs/es_AR.json
+++ b/nwg_clipman/langs/es_AR.json
@@ -1,8 +1,8 @@
 {
-  "clear": "Claro",
+  "clear": "Borrar",
   "clear-clipboard-history": "Borrar historial del portapapeles",
-  "close": "Cerca",
+  "close": "Cerrar",
   "copy": "Copiar",
-  "preview": "Avance",
+  "preview": "Vista previa",
   "preview-unavailable": "Vista previa no disponible"
 }

--- a/nwg_clipman/langs/es_ES.json
+++ b/nwg_clipman/langs/es_ES.json
@@ -1,8 +1,8 @@
 {
-  "clear": "Claro",
+  "clear": "Borrar",
   "clear-clipboard-history": "Borrar historial del portapapeles",
-  "close": "Cerca",
+  "close": "Cerrar",
   "copy": "Copiar",
-  "preview": "Avance",
+  "preview": "Vista previa",
   "preview-unavailable": "Vista previa no disponible"
 }


### PR DESCRIPTION
This PR fixes some unintended spanish translations

- "Claro" is unintended here, "Borrar" or "Limpiar" is what should be used.
- "Avance" could fit but "Vista previa" is IMHO a lot better, it is also used below.
- "Cerca" means literally 'Close' as in "He's close to me". "Cerrar" is what is intended.