### PR TITLE
Feature request: Allow copying a clipboard entry upon second selection

### DIFF
--- a/nwg_clipman/main.py
+++ b/nwg_clipman/main.py
@@ -157,6 +157,10 @@ def flowbox_filter(_search_entry):
 def on_child_activated(fb, child):
     # on flowbox item clicked
     global selected_item
+    # If the item was already clicked - copy it
+    if selected_item == child.get_name():
+        on_copy_button(None)
+    # If not, show full entry preview
     selected_item = child.get_name()
     name = bytes(child.get_name(), 'utf-8')
     subprocess.run(f"cliphist decode > {tmp_file}", shell=True, input=name)


### PR DESCRIPTION
Hello and thank you for the project! 
As of now (v0.2.7), it's not always convenient to select a clipboard entry and then click the copy button. To rectify this, I propose to copy entries to the clipboard if they get activated in the UI for a second time (either by clicking or hitting Enter one more time) . This makes it much easier to copy entries with the keyboard, not needing to switch focus to the copy button, and feels natural for the mouse to copy an entry by, essentially, double-clicking it.